### PR TITLE
New select group

### DIFF
--- a/card.php
+++ b/card.php
@@ -43,7 +43,6 @@ if (empty($reshook))
 			$PDOdb->beginTransaction();
 			
 			$missionorder->set_values($_REQUEST); // Set standard attributes
-			
 			$missionorder->date_start = dol_mktime(GETPOST('starthour'), GETPOST('startmin'), 0, GETPOST('startmonth'), GETPOST('startday'), GETPOST('startyear'));
 			$missionorder->date_end = dol_mktime(GETPOST('endhour'), GETPOST('endmin'), 0, GETPOST('endmonth'), GETPOST('endday'), GETPOST('endyear'));
 			
@@ -213,6 +212,7 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	
 	$htmlProject = getProjectView($mode, $missionorder->fk_project);
 	$htmlUsers = getUsersView($missionorder->TMissionOrderUser, $form, $mode);
+	$htmlUsergroup = getUsergroupView($mode, $missionorder->fk_usergroup);
 	
 	$htmlDateStart = getDateView($form, $missionorder->date_start, $mode, 'start');
 	$htmlDateEnd = getDateView($form, $missionorder->date_end, $mode, 'end');
@@ -227,6 +227,7 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	if ($mode == 'edit') echo $formcore->begin_form($_SERVER['PHP_SELF'], 'form_mission_order');
 	
 	$TUsersGroup = $missionorder->getUsersGroup(1);
+	
 	$is_valideur = !empty($conf->valideur->enabled) ? TRH_valideur_groupe::isValideur($PDOdb, $user->id, $TUsersGroup, false, 'missionOrder') : false;
 	$can_create_ndfp = !empty($conf->ndfp->enabled) && $user->rights->ndfp->myactions->create && ($missionorder->status == TMissionOrder::STATUS_ACCEPTED || (!empty($conf->global->MISSION_ORDER_ALLOW_CREATE_NDFP_FROM_TO_APPROVE) && $missionorder->status == TMissionOrder::STATUS_TO_APPROVE) );
 	
@@ -260,6 +261,7 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 				,'showCarriage' => $htmlCarriage
 				,'showNote' => $formcore->zonetexte('', 'note', $missionorder->note, 80, 8)
 				,'showStatus' => $missionorder->getLibStatut(1)
+				,'showUsergroup' => $htmlUsergroup
 			)
 			,'langs' => $langs
 			,'form' => $form

--- a/card.php
+++ b/card.php
@@ -65,10 +65,10 @@ if (empty($reshook))
 				setEventMessages($langs->trans('warning_no_user_linked'), array(), 'warnings');
 			}
 			
-			if (empty($missionorder->fk_project))
+			if (empty($missionorder->fk_usergroup))
 			{
 				$error++;
-				setEventMessages($langs->trans('warning_no_project_selected'), array(), 'warnings');
+				setEventMessages($langs->trans('warning_no_usergroup_selected'), array(), 'warnings');
 			}
 			
 			if ($error)

--- a/card.php
+++ b/card.php
@@ -211,7 +211,7 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	$formconfirm = getFormConfirm($PDOdb, $form, $missionorder, $action);
 	if (!empty($formconfirm)) echo $formconfirm;
 	
-	if(empty($missionorder->ref))$missionorder->TMissionOrderUser = array($user);
+	if(empty($missionorder->ref))$missionorder->TMissionOrderUser = array($user); // Si on est à la création on prérempli le select user avec le user createur
 	$htmlProject = getProjectView($mode, $missionorder->fk_project,$missionorder->TMissionOrderUser);
 	$htmlUsers = getUsersView($missionorder->TMissionOrderUser, $form, $mode);
 	$htmlUsergroup = getUsergroupView($mode, $missionorder->fk_usergroup,$missionorder->TMissionOrderUser);
@@ -285,6 +285,7 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	if ($mode == 'view') $somethingshown = $form->showLinkedObjectBlock($missionorder->generic);
 	
 	?>
+<!-- MAJ EN TEMPS REEL DES SELECT EN FCT DES USERS SELECTED -->
 		<script type='text/javascript'>
 			$(document).ready(function(){
 				$('#TUser').on('change',function (data) {

--- a/card.php
+++ b/card.php
@@ -17,7 +17,6 @@ $action = GETPOST('action');
 $id = GETPOST('id', 'int');
 $ref = GETPOST('ref');
 $mode = GETPOST('mode');
-
 if (empty($mode)) $mode = 'view';
 if ($action == 'create' || $action == 'edit') $mode = 'edit';
 
@@ -39,6 +38,7 @@ if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'e
 if (empty($reshook))
 {
 	$error = 0;
+	
 	switch ($action) {
 		case 'save':
 			$PDOdb->beginTransaction();
@@ -150,7 +150,7 @@ if (empty($reshook))
 				$ndfp->dates = $missionorder->date_start;
 				$ndfp->datee = $missionorder->date_end;
 				$ndfp->type = 'NORMAL'; // ou FORMATION
-				$ndfp->fk_project = $missionorder->fk_project;
+				$ndfp->fk_project = ($missionorder->fk_project>0)?$missionorder->fk_project:0;
 				$ndfp->description = $missionorder->label;
 				
 				$ndfp->fk_user = $user->id;
@@ -210,8 +210,9 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	
 	$formconfirm = getFormConfirm($PDOdb, $form, $missionorder, $action);
 	if (!empty($formconfirm)) echo $formconfirm;
-	
+
 	if(empty($missionorder->ref))$missionorder->TMissionOrderUser = array($user); // Si on est à la création on prérempli le select user avec le user createur
+	
 	$htmlProject = getProjectView($mode, $missionorder->fk_project,$missionorder->TMissionOrderUser);
 	$htmlUsers = getUsersView($missionorder->TMissionOrderUser, $form, $mode);
 	$htmlUsergroup = getUsergroupView($mode, $missionorder->fk_usergroup,$missionorder->TMissionOrderUser);

--- a/card.php
+++ b/card.php
@@ -5,6 +5,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 dol_include_once('/missionorder/class/missionorder.class.php');
 dol_include_once('/missionorder/lib/missionorder.lib.php');
+dol_include_once('/projet/class/project.class.php');
 if (!empty($conf->valideur->enabled)) dol_include_once('/valideur/class/valideur.class.php');
 
 if (empty($user->rights->missionorder->read)) accessforbidden();
@@ -210,9 +211,10 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	$formconfirm = getFormConfirm($PDOdb, $form, $missionorder, $action);
 	if (!empty($formconfirm)) echo $formconfirm;
 	
-	$htmlProject = getProjectView($mode, $missionorder->fk_project);
+	if(empty($missionorder->ref))$missionorder->TMissionOrderUser = array($user);
+	$htmlProject = getProjectView($mode, $missionorder->fk_project,$missionorder->TMissionOrderUser);
 	$htmlUsers = getUsersView($missionorder->TMissionOrderUser, $form, $mode);
-	$htmlUsergroup = getUsergroupView($mode, $missionorder->fk_usergroup);
+	$htmlUsergroup = getUsergroupView($mode, $missionorder->fk_usergroup,$missionorder->TMissionOrderUser);
 	
 	$htmlDateStart = getDateView($form, $missionorder->date_start, $mode, 'start');
 	$htmlDateEnd = getDateView($form, $missionorder->date_end, $mode, 'end');
@@ -282,5 +284,47 @@ function _fiche(&$PDOdb, &$missionorder, $mode='view', $action)
 	
 	if ($mode == 'view') $somethingshown = $form->showLinkedObjectBlock($missionorder->generic);
 	
+	?>
+		<script type='text/javascript'>
+			$(document).ready(function(){
+				$('#TUser').on('change',function (data) {
+					$.ajax({
+						url : "./script/interface.php"
+						,data: {
+							json:1
+							,get : 'project'
+							,TUserId : data.val
+
+						}
+						,dataType: 'json'
+					})
+					.done(function (result) {
+						$("#fk_project").replaceWith(result);
+						
+					}); 
+					
+					$.ajax({
+						url : "./script/interface.php"
+						,data: {
+							json:1
+							,get : 'usergroup'
+							,TUserId : data.val
+
+						}
+						,dataType: 'json'
+					})
+					.done(function (result) {
+						$("#fk_usergroup").replaceWith(result);
+						
+					}); 
+				});
+				
+			});
+		
+
+		</script>
+				
+	<?php
+
 	llxFooter();
 }

--- a/class/missionorder.class.php
+++ b/class/missionorder.class.php
@@ -640,9 +640,14 @@ class TMissionOrder extends TObjetStd
 		
 		$TGroupUser = $this->getUsersGroup(1);
 		
+		$onMission=false;
+		foreach($this->TUser as $userMission){
+			if($userMission->id == $user->id)$onMission=true; 
+		}
+		
 		if (!TRH_valideur_groupe::isValideur($PDOdb, $user->id, $TGroupUser, false, 'missionOrder')) return false;
 		elseif (TRH_valideur_object::alreadyAcceptedByThisUser($PDOdb, $this->entity, $user->id, $this->getId(), 'missionOrder')) return false;
-		elseif ($this->fk_user == $user->id && !TRH_valideur_groupe::validHimSelf($user, $this, 'missionOrder')) return false;
+		elseif ($onMission && !TRH_valideur_groupe::validHimSelf($user, $this, 'missionOrder')) return false;
 		
 		$TLevelValidation = TRH_valideur_groupe::getTLevelValidation($PDOdb, $user, 'missionOrder', $TGroupUser);
 		$intersect = array_intersect($TGroupUser, array_keys($TLevelValidation));

--- a/class/missionorder.class.php
+++ b/class/missionorder.class.php
@@ -53,7 +53,7 @@ class TMissionOrder extends TObjetStd
 		$this->add_champs('label,location,other_reason,other_carriage', array('type' => 'string'));
 		$this->add_champs('status', array('type' => 'integer'));
 		
-		$this->add_champs('fk_project,entity,fk_user_author,fk_user_valid', array('type' => 'integer', 'index' => true));
+		$this->add_champs('fk_project,entity,fk_user_author,fk_user_valid,fk_usergroup', array('type' => 'integer', 'index' => true));
 		$this->add_champs('date_start,date_end,date_valid,date_refuse,date_accept', array('type' => 'date'));
 		$this->add_champs('note', array('type' => 'text'));
 		$this->add_champs('level', array('type' => 'integer', 'default' => 1));
@@ -260,7 +260,7 @@ class TMissionOrder extends TObjetStd
 	{
 		$this->status = self::STATUS_TO_APPROVE;
 		$this->withChild = false;
-
+		
 		$TUser = $this->getUserFromMission();
 		$TValideur = $this->getTValideurFromTUser($PDOdb, $TUser);
 		

--- a/class/missionorder.class.php
+++ b/class/missionorder.class.php
@@ -263,7 +263,7 @@ class TMissionOrder extends TObjetStd
 		
 		$TUser = $this->getUserFromMission();
 		$TValideur = $this->getTValideurFromTUser($PDOdb, $TUser);
-		
+
 		$from = $this->getFirstMailFromUser($TUser);
 		$to = $this->concatMailFromUser($TValideur);
 		$addr_cc ='';// $this->concatMailFromUser($TUser);
@@ -534,6 +534,9 @@ class TMissionOrder extends TObjetStd
 	{
 		global $db;
 		
+		if(!empty($this->fk_usergroup))return array($this->fk_usergroup);
+		
+		
 		require_once DOL_DOCUMENT_ROOT.'/user/class/usergroup.class.php';
 		
 		$TGroup = array();
@@ -636,6 +639,7 @@ class TMissionOrder extends TObjetStd
 		if ($this->status != TMissionOrder::STATUS_TO_APPROVE) return false;
 		
 		$TGroupUser = $this->getUsersGroup(1);
+		
 		if (!TRH_valideur_groupe::isValideur($PDOdb, $user->id, $TGroupUser, false, 'missionOrder')) return false;
 		elseif (TRH_valideur_object::alreadyAcceptedByThisUser($PDOdb, $this->entity, $user->id, $this->getId(), 'missionOrder')) return false;
 		elseif ($this->fk_user == $user->id && !TRH_valideur_groupe::validHimSelf($user, $this, 'missionOrder')) return false;

--- a/class/missionorder.class.php
+++ b/class/missionorder.class.php
@@ -641,7 +641,7 @@ class TMissionOrder extends TObjetStd
 		$TGroupUser = $this->getUsersGroup(1);
 		
 		$onMission=false;
-		foreach($this->TUser as $userMission){
+		foreach($this->TUser as $userMission){ // On check sur tous les users s'il est dans l'ordre de mission
 			if($userMission->id == $user->id)$onMission=true; 
 		}
 		

--- a/core/modules/modmissionorder.class.php
+++ b/core/modules/modmissionorder.class.php
@@ -58,7 +58,7 @@ class modmissionorder extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module missionorder";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1';
+		$this->version = '1.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/langs/fr_FR/missionorder.lang
+++ b/langs/fr_FR/missionorder.lang
@@ -68,6 +68,7 @@ Reopen=Rouvrir
 NewMissionOrder=Nouvel ordre de mission
 ValidateAndSendToBeApprove=Valider et envoyer pour approbation
 NextValideur=Prochain(s) valideur(s)
+UserGroupLinked=Groupe associé
 
 # FROM OBJECT
 MissionOrderStatusDraft=Brouillon (à valider)

--- a/langs/fr_FR/missionorder.lang
+++ b/langs/fr_FR/missionorder.lang
@@ -81,7 +81,7 @@ MissionOrderStatusAccepted=Acceptée (fermée)
 warning_date_start_end_must_be_fill=Attention : les dates de début et de fin sont obligatoires
 warning_date_start_must_be_inferior_as_date_end=Attention : la date de début doit être inférieur à la date de fin
 warning_no_user_linked=Attention : l'association à un utilisateur est obligatoire
-warning_no_project_selected=Attention : l'association à un projet est obligatoire
+warning_no_usergroup_selected=Attention : l'association à un groupe est obligatoire
 warning_fk_user_fetch_fail=Attention : échec sur le chargement d'un utilisateur [id : %d]
 warning_fk_project_fetch_fail=Attention : échec sur le chargement du projet [id : %d]
 

--- a/lib/missionorder.lib.php
+++ b/lib/missionorder.lib.php
@@ -80,19 +80,58 @@ function mission_order_prepare_head(TMissionOrder $object)
 	return $head;
 }
 
-function getProjectView($mode='view', $fk_project=0)
+function getProjectView($mode='view', $fk_project=0, $TUser=array())
 {
 	global $db,$langs,$conf;
 	
 	if ($mode == 'edit')
 	{
 		require_once DOL_DOCUMENT_ROOT.'/core/class/html.formprojet.class.php';
-	
-		$formproject = new FormProjets($db);
-		ob_start();
-		$formproject->select_projects(-1, $fk_project, 'fk_project', 16, 0, 1, $conf->global->PROJECT_HIDE_UNSELECTABLES);
-		$htmlProject = ob_get_clean();
 		
+		$TProjects = array();
+		if (!empty($TUser))
+		{
+			$count_user_project_common = array();
+			foreach ($TUser as $user)
+			{// Pour chaque user on récupère ses projets pour lesquels il est contact
+				if (!empty($user->fk_user))
+					$user->id = $user->fk_user; // Si Tobjetuserordermission user id contenu dans fk user sinon c'est directement un objet user
+				$sql = "SELECT DISTINCT element_id FROM ".MAIN_DB_PREFIX.'element_contact ec WHERE fk_socpeople='.$user->id.' AND fk_c_type_contact IN (160,161)';
+				$resql = $db->query($sql);
+				if (!empty($resql))
+				{
+					while ($obj = $db->fetch_object($resql))
+					{
+						$proj = new Project($db);
+						$proj->fetch($obj->element_id);
+						if ($proj->statut != 2)
+						{// On récupère les projets qui ne sont pas cloturés
+							if (!empty($TProjects[$proj->id]))
+							{
+								$count_user_project_common[$proj->id] ++;
+								if (empty($fk_project) && ($count_user_project_common[$proj->id] == count($TUser)))
+									$fk_project = $proj->id; // Si un projet en commun on le préselectionne
+							}else
+							{ // On peuple le select
+								$TProjects[$proj->id] = $proj->ref;
+								$count_user_project_common[$proj->id] = 1;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if (count($TProjects) == 1)
+		{// Si un seul projet on le préselectionne
+			reset($TProjects);
+			$fk_project = key($TProjects);
+		}
+		$form = new Form($db);
+		ob_start();
+		print $form->selectarray('fk_project', $TProjects, $fk_project, 1, 0, 0, '', 0, 0, 0, '', 'minwidth100');
+		$htmlProject = ob_get_clean();
+
 		return $htmlProject;
 	}
 	elseif ($fk_project > 0) // mode view mais uniquement si le fetch d'un projet en vos la peine
@@ -126,8 +165,10 @@ function getUsersView(&$TMissionOrderUser, &$form, $mode='view')
 		foreach ($TMissionOrderUser as $missionOrderUser)
 		{
 			$TSelectedUser[] = $missionOrderUser->fk_user;
+			if($missionOrderUser->element == 'user')$TSelectedUser[]=$missionOrderUser->id;
 		}
-		if(empty($TSelectedUser))$TSelectedUser=array($user->id);
+		
+		//if(empty($TSelectedUser))$TSelectedUser=array($user->id);
 		$res = $form->multiselectarray('TUser', $TUser, $TSelectedUser, 0, 0, '', 0, '95%', '', '');
 	}
 	elseif (!empty($TMissionOrderUser))
@@ -149,7 +190,7 @@ function getUsersView(&$TMissionOrderUser, &$form, $mode='view')
 	return $res;
 }
 
-function getUsergroupView($mode='view', $fk_usergroup=0)
+function getUsergroupView($mode='view', $fk_usergroup=0,$TUser=array())
 {
 	global $db,$langs,$conf, $user;
 	
@@ -157,21 +198,51 @@ function getUsergroupView($mode='view', $fk_usergroup=0)
 	{
 		require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 		dol_include_once('/user/class/usergroup.class.php');
-		
-		$group = new UserGroup($db);
-		$listgroup = $group->listGroupsForUser($user->id);
+
 		$viewGroup = array();
-		if(!empty($listgroup)){
-			foreach($listgroup as $grpid => $grp){
-				$viewGroup[$grpid]=$grp->nom;
+		if (!empty($TUser))
+		{
+			$count_user_usergrp_common = array();
+			foreach ($TUser as $user)//Pour chaque user récupérer ses groupes
+			{
+				
+
+				$group = new UserGroup($db);
+				if(!empty($user->fk_user))$user->id = $user->fk_user;//Si on a un objet Tmissionorderuser et pas un objet user
+				$listgroup = $group->listGroupsForUser($user->id);
+				if (!empty($listgroup))
+				{
+					
+					foreach ($listgroup as $grpid => $grp)
+					{
+						
+						if (!empty($viewGroup[$grpid]))
+						{
+							$count_user_usergrp_common[$grpid] ++;
+							
+							if (empty($fk_usergroup) && ($count_user_usergrp_common[$grpid] == count($TUser))){//Si  on a un groupe en commun
+								$fk_usergroup = $grpid;
+								
+							}
+						}else
+						{//On peuple le select
+							$viewGroup[$grpid] = $grp->nom;
+							$count_user_usergrp_common[$grpid] = 1;
+						}
+					}
+				}
 			}
 		}
+
 		
-		
+		if(count($viewGroup) == 1){//Si on a un seul groupe
+			reset($viewGroup);
+			$fk_usergroup = key($viewGroup);
+		}
 		
 		$form = new Form($db);
 		ob_start();
-		print $form->selectarray('fk_usergroup',$viewGroup, $fk_usergroup);
+		print $form->selectarray('fk_usergroup',$viewGroup, $fk_usergroup,1,0,0,'',0,0,0,'','minwidth100');
 		$htmlProject = ob_get_clean();
 		
 		return $htmlProject;

--- a/lib/missionorder.lib.php
+++ b/lib/missionorder.lib.php
@@ -94,7 +94,7 @@ function getProjectView($mode='view', $fk_project=0, $TUser=array())
 			$count_user_project_common = array();
 			foreach ($TUser as $user)
 			{// Pour chaque user on récupère ses projets pour lesquels il est contact
-				if (!empty($user->fk_user))
+				if (!empty($user->fk_user) && $user->element != 'user')
 					$user->id = $user->fk_user; // Si Tobjetuserordermission user id contenu dans fk user sinon c'est directement un objet user
 				$sql = "SELECT DISTINCT element_id FROM ".MAIN_DB_PREFIX.'element_contact ec WHERE fk_socpeople='.$user->id.' AND fk_c_type_contact IN (160,161)';
 				$resql = $db->query($sql);
@@ -162,10 +162,12 @@ function getUsersView(&$TMissionOrderUser, &$form, $mode='view')
 	{
 		$TUser = getAllUserNameById();
 		$TSelectedUser = array();
+		
 		foreach ($TMissionOrderUser as $missionOrderUser)
 		{
-			$TSelectedUser[] = $missionOrderUser->fk_user;
 			if($missionOrderUser->element == 'user')$TSelectedUser[]=$missionOrderUser->id;
+			else $TSelectedUser[] = $missionOrderUser->fk_user;
+			
 		}
 		
 		//if(empty($TSelectedUser))$TSelectedUser=array($user->id);
@@ -208,7 +210,7 @@ function getUsergroupView($mode='view', $fk_usergroup=0,$TUser=array())
 				
 
 				$group = new UserGroup($db);
-				if(!empty($user->fk_user))$user->id = $user->fk_user;//Si on a un objet Tmissionorderuser et pas un objet user
+				if(!empty($user->fk_user)&& $user->element!='user')$user->id = $user->fk_user;//Si on a un objet Tmissionorderuser et pas un objet user
 				$listgroup = $group->listGroupsForUser($user->id);
 				if (!empty($listgroup))
 				{

--- a/lib/missionorder.lib.php
+++ b/lib/missionorder.lib.php
@@ -149,6 +149,51 @@ function getUsersView(&$TMissionOrderUser, &$form, $mode='view')
 	return $res;
 }
 
+function getUsergroupView($mode='view', $fk_usergroup=0)
+{
+	global $db,$langs,$conf, $user;
+	
+	if ($mode == 'edit')
+	{
+		require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+		dol_include_once('/user/class/usergroup.class.php');
+		
+		$group = new UserGroup($db);
+		$listgroup = $group->listGroupsForUser($user->id);
+		$viewGroup = array();
+		if(!empty($listgroup)){
+			foreach($listgroup as $grpid => $grp){
+				$viewGroup[$grpid]=$grp->nom;
+			}
+		}
+		
+		
+		
+		$form = new Form($db);
+		ob_start();
+		print $form->selectarray('fk_usergroup',$viewGroup, $fk_usergroup);
+		$htmlProject = ob_get_clean();
+		
+		return $htmlProject;
+	}
+	elseif ($fk_usergroup > 0) // mode view mais uniquement si le fetch d'un projet en vos la peine
+	{
+		dol_include_once('/user/class/usergroup.class.php');
+		
+		$group = new UserGroup($db);
+		if ($group->fetch($fk_usergroup) > 0)
+		{
+			return $group->getNomUrl(1, '', 1);
+		}
+		else
+		{
+			setEventMessages($langs->trans('warning_fk_group_fetch_fail', $fk_usergroup), array(), 'warnings');
+		}
+	}
+	
+	return '';
+}
+
 function getAllUserNameById()
 {
 	global $db,$langs,$conf,$user;

--- a/lib/missionorder.lib.php
+++ b/lib/missionorder.lib.php
@@ -115,7 +115,7 @@ function getProjectView($mode='view', $fk_project=0)
 
 function getUsersView(&$TMissionOrderUser, &$form, $mode='view')
 {
-	global $db,$langs;
+	global $db,$langs,$user;
 	
 	$res = '';
 	
@@ -127,7 +127,7 @@ function getUsersView(&$TMissionOrderUser, &$form, $mode='view')
 		{
 			$TSelectedUser[] = $missionOrderUser->fk_user;
 		}
-		
+		if(empty($TSelectedUser))$TSelectedUser=array($user->id);
 		$res = $form->multiselectarray('TUser', $TUser, $TSelectedUser, 0, 0, '', 0, '95%', '', '');
 	}
 	elseif (!empty($TMissionOrderUser))

--- a/lib/missionorder.lib.php
+++ b/lib/missionorder.lib.php
@@ -243,9 +243,9 @@ function getUsergroupView($mode='view', $fk_usergroup=0,$TUser=array())
 		$form = new Form($db);
 		ob_start();
 		print $form->selectarray('fk_usergroup',$viewGroup, $fk_usergroup,1,0,0,'',0,0,0,'','minwidth100');
-		$htmlProject = ob_get_clean();
+		$htmlUsergroup = ob_get_clean();
 		
-		return $htmlProject;
+		return $htmlUsergroup;
 	}
 	elseif ($fk_usergroup > 0) // mode view mais uniquement si le fetch d'un projet en vos la peine
 	{

--- a/list.php
+++ b/list.php
@@ -2,6 +2,7 @@
 
 require 'config.php';
 dol_include_once('/missionorder/class/missionorder.class.php');
+dol_include_once('/projet/class/project.class.php');
 if (!empty($conf->valideur->enabled)) dol_include_once ('/valideur/class/valideur.class.php');
 
 if(empty($user->rights->missionorder->read)) accessforbidden();
@@ -201,11 +202,12 @@ function _list()
 function _getProjectNomUrl($fk_project)
 {
 	global $db;
-	
-	$project = new Project($db);
-	$project->fetch($fk_project);
-	
-	return $project->getNomUrl(1, '', 1);
+	if(!empty($fk_project)){
+		$project = new Project($db);
+		$project->fetch($fk_project);
+
+		return $project->getNomUrl(1, '', 1);
+	}
 }
 
 function _formatDate($date)

--- a/list.php
+++ b/list.php
@@ -102,7 +102,6 @@ function _list()
 	}
 	
 	$sql.= ' GROUP BY mo.rowid';
-
 	$TFiltre = GETPOST('TListTBS', 'array');
 	if (empty($TFiltre['list_llx_mission_order'])) $sql.=' ORDER BY mo.rowid DESC';
 	
@@ -202,7 +201,7 @@ function _list()
 function _getProjectNomUrl($fk_project)
 {
 	global $db;
-	if(!empty($fk_project)){
+	if($fk_project > 0){
 		$project = new Project($db);
 		$project->fetch($fk_project);
 

--- a/script/interface.php
+++ b/script/interface.php
@@ -1,0 +1,50 @@
+<?php
+
+require ('../config.php');
+dol_include_once('/missionorder/lib/missionorder.lib.php');
+dol_include_once('/projet/class/project.class.php');
+dol_include_once('/missionorder/lib/missionorder.lib.php');
+
+
+$get = GETPOST('get','alpha');
+$put = GETPOST('put','alpha');
+
+_put($db, $put);
+_get($db, $get);
+
+function _get(&$db, $case) {
+
+	switch ($case) {
+		case 'project':
+			$TUserId = GETPOST('TUserId');
+			if(!empty($TUserId)){
+				foreach($TUserId as &$userId){
+					$obj = new stdClass();
+					$obj->id = $userId;
+					$userId=$obj;
+				}
+			}
+			echo json_encode(getProjectView('edit',0,$TUserId));
+			break;
+		case 'usergroup':
+			$TUserId = GETPOST('TUserId');
+			if(!empty($TUserId)){
+				foreach($TUserId as &$userId){
+					$obj = new stdClass();
+					$obj->id = $userId;
+					$userId=$obj;
+				}
+			}
+			echo json_encode(getUsergroupView('edit',0,$TUserId));
+			break;
+		
+	}
+
+}
+
+function _put(&$db, $case) {
+	switch ($case) {
+        
+	}
+
+}

--- a/tpl/card.tpl.php
+++ b/tpl/card.tpl.php
@@ -18,7 +18,7 @@
 			</tr>
 
 			<tr class="project">
-				<td width="25%" class="fieldrequired">[langs.transnoentities(ProjectLinked)]</td>
+				<td width="25%" >[langs.transnoentities(ProjectLinked)]</td>
 				<td>[view.showProject;strconv=no]</td>
 			</tr>
 

--- a/tpl/card.tpl.php
+++ b/tpl/card.tpl.php
@@ -26,6 +26,11 @@
 				<td width="25%" class="fieldrequired">[langs.transnoentities(UsersLinked)]</td>
 				<td>[view.showUsers;strconv=no]</td>
 			</tr>
+			
+			<tr class="usergroup">
+				<td width="25%" class="fieldrequired">[langs.transnoentities(UserGroupLinked)]</td>
+				<td>[view.showUsergroup;strconv=no]</td>
+			</tr>
 
 			<tr class="location">
 				<td width="25%">[langs.transnoentities(Location)]</td>


### PR DESCRIPTION
Champ projet à redéfinir :
- le champ projet actuel ne devient plus obligatoire
- lorsqu'un étudiant créé un OM alors, s'il est affecté en tant que contact d'un seul seul projet, le projet est automatiquement sélectionné dans la liste déroulante. S'il est affecté à plusieurs projets alors il devra sélectionner lui même le projet à rattacher à l'OM (ce qui ne devrait normalement pas arriver)
- lorsqu'un membre du personnel créé un OM, le champ projet restera vide ce qui ne posera pas de problème vu qu'il ne sera plus obligatoire

Choix du groupe de validation pour les OM :
- nous allons ajouter une liste déroulante permettant aux utilisateurs de sélectionner leur groupe afin de détecter quel est le cycle de validation à appliquer. Celle-ci sera vide par défaut et se remplira automatiquement à chaque ajout d'un utilisateur affecté à l'OM par le biais du champ prévu à cet effet
- cette liste se présélectionnera automatiquement si un seul choix est possible dans la liste, dans le cas contraire l'utilisateur devra sélectionner manuellement le groupe de validation
- ce champ sera obligatoire
